### PR TITLE
PHPUnit install from phpunit.de

### DIFF
--- a/ansible/roles/phpunit/tasks/main.yml
+++ b/ansible/roles/phpunit/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
-- name:    Configure PEAR for PHPUnit
-  sudo:    yes
-  command: pear config-set auto_discover 1
+- name:    Download PHPUnit
+  sudo:    no
+  command: wget https://phar.phpunit.de/phpunit.phar
 
-- name:    Install PHPUnit
+- name:    Add executable permissions to PHPUnit
+  sudo:    no
+  command: chmod +x phpunit.phar
+
+- name:    Move PHPunit to /usr/local/bin
   sudo:    yes
-  command: pear install pear.phpunit.de/PHPUnit creates=/usr/bin/phpunit
+  command: mv phpunit.phar /usr/local/bin/phpunit


### PR DESCRIPTION
Installation of PHPUnit from Pear fails, I would be better way to have it installed from phpunit.de.


End of Life for PEAR Installation Method
https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method