### PR TITLE
Add sqlite to php

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -15,6 +15,7 @@
       - { name: redis, package: php5-redis }
       - { name: apc, package: php-apc }
       - { name: memcached, package: php5-memcached }
+      - { name: sqlite, package: php5-sqlite }
     php_extensions:
       - { name: "jsmin", package: "pecl.php.net/jsmin-beta" }
       - { name: "mongo", package: "pecl.php.net/mongo" }


### PR DESCRIPTION
I added sqlite to php. The goal is to be able to use sqlite as database for functional testing (with [LiipFunctionalTestBundle](https://github.com/liip/LiipFunctionalTestBundle) for example).

That solve the issue `PDOException: could not find driver`.